### PR TITLE
made old entries less visible

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -28,10 +28,19 @@ foreach ($res as $val) {
         $place = $numContenders;
     }
     $last = $val["top"];
+    
+    // Has it been updated today?
+    $today = date("Y-m-d");
+    $updated = date("Y-m-d", strtotime($val["updated"]));
+    if ($today == $updated) {
+        $classOld = "";
+    } else {
+        $classOld = ' class="old"';
+    }
 
     $name = htmlentities($val["whoName"]);
     $html .= <<<EOD
-    <tr>
+    <tr${classOld}>
         <td>$place</td>
         <td>$name</td>
         <td class="right">${val["top"]}</td>
@@ -57,6 +66,9 @@ td {
 }
 tr:hover {
     background-color: #eee;
+}
+tr.old {
+    color: #ccc;
 }
 </style>
 


### PR DESCRIPTION
This code will make old entries written with a light grey color so that they're faded compared to recently updated entries. It's based on the current date. Only entries updated on the current date will be written in black.

Downside: Everything will be written with a light grey color between midnight and 8 am, unless contestants update their cron script.