### PR TITLE
Added missing <title>

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -54,6 +54,7 @@ EOD;
 <!doctype html>
 <html lang="sv">
 <meta charset="utf-8">
+<title>Uptime Topplista</title>
 <style>
 td.right {
     text-align: right;


### PR DESCRIPTION
The page had no title tag, added with the title of 'Uptime Topplista'.